### PR TITLE
Populate blog list from shared metadata

### DIFF
--- a/global.css
+++ b/global.css
@@ -785,6 +785,10 @@ projects-item {
   text-decoration: none;
 }
 
+#blog-posts a p {
+  margin: 0;
+}
+
 @keyframes underline-animate {
   from{
 

--- a/index.html
+++ b/index.html
@@ -189,10 +189,9 @@
         <div id="blog-container">
           <div id="blog-posts">
             <h3>Posts</h3>
-            <a href="/blog/When-AI-Wants-To-Survive"><p id="title">When AI Wants to Survive</p><p id=date>4/29/25</p></a>
+            <div id="blog-post-list"></div>
             <h4>Ongoing</h4>
-            <a href="/blog/Reading-List"><p id="title">Reading List</p><p id=date></p></a>
-            <a href="/blog/Poetry"><p id="title">Poetry</p></a>
+            <div id="blog-post-ongoing-list"></div>
           </div>
         </div>
     </section>

--- a/main.js
+++ b/main.js
@@ -3,6 +3,22 @@ const HOMEPAGE_OPENING_ANIMATION_TIME = 600;
 
 let timeoutID;
 
+const blogPosts = new Map([
+    ["When-AI-Wants-To-Survive", {
+        title: "When AI Wants to Survive",
+        date: "2025-04-29",
+        status: "published",
+    }],
+    ["Reading-List", {
+        title: "Reading List",
+        status: "ongoing",
+    }],
+    ["Poetry", {
+        title: "Poetry",
+        status: "ongoing",
+    }],
+]);
+
 /** Start of code for routing with animations */
 document.addEventListener("click", (e) => {
     const {target} = e;
@@ -485,12 +501,98 @@ function openBlog(e, pushState = true) {
     }
 }
 
+function formatBlogPostDate(dateString) {
+    if(!dateString) {
+        return "";
+    }
+
+    const date = new Date(dateString);
+    if(Number.isNaN(date.getTime())) {
+        return dateString;
+    }
+
+    return date.toLocaleDateString("en-US", {
+        month: "numeric",
+        day: "numeric",
+        year: "2-digit",
+    });
+}
+
+function createBlogPostLink({slug, title, date}) {
+    const link = document.createElement("a");
+    link.href = `/blog/${slug}`;
+
+    const titleElement = document.createElement("p");
+    titleElement.className = "blog-post-title";
+    titleElement.textContent = title;
+    link.appendChild(titleElement);
+
+    const dateElement = document.createElement("p");
+    dateElement.className = "blog-post-date";
+    dateElement.textContent = formatBlogPostDate(date);
+    link.appendChild(dateElement);
+
+    return link;
+}
+
+function populateBlogPostList() {
+    const postListContainer = document.getElementById("blog-post-list");
+    const ongoingListContainer = document.getElementById("blog-post-ongoing-list");
+
+    if(!postListContainer && !ongoingListContainer) {
+        return;
+    }
+
+    const publishedPosts = [];
+    const ongoingPosts = [];
+
+    blogPosts.forEach((post, slug) => {
+        const status = post.status || "published";
+        const postData = {slug, title: post.title, date: post.date};
+
+        if(status === "ongoing") {
+            ongoingPosts.push(postData);
+            return;
+        }
+
+        publishedPosts.push(postData);
+    });
+
+    publishedPosts.sort((a, b) => {
+        const aTime = a.date ? new Date(a.date).getTime() : 0;
+        const bTime = b.date ? new Date(b.date).getTime() : 0;
+
+        if(aTime !== bTime) {
+            return bTime - aTime;
+        }
+
+        return a.title.localeCompare(b.title);
+    });
+
+    ongoingPosts.sort((a, b) => a.title.localeCompare(b.title));
+
+    if(postListContainer) {
+        postListContainer.innerHTML = "";
+        publishedPosts.forEach((post) => {
+            postListContainer.appendChild(createBlogPostLink(post));
+        });
+    }
+
+    if(ongoingListContainer) {
+        ongoingListContainer.innerHTML = "";
+        ongoingPosts.forEach((post) => {
+            ongoingListContainer.appendChild(createBlogPostLink(post));
+        });
+    }
+}
+
 function initBlog() {
     let main = document.querySelector('main');
     let blogTpl = document.getElementById('blog-tpl');
     main.append(blogTpl.content.cloneNode(true));
 
     document.body.style.backgroundColor = "var(--blog-background-color)";
+    populateBlogPostList();
 }
 
 function removeBlog(){
@@ -501,16 +603,28 @@ function openBlogPost() {
     let main = document.querySelector('main');
     let blogPostTpl = document.getElementById('blog-post-tpl');
 
-    // to ensure no glitching get rid of other content, this is OK because blog 
+    // to ensure no glitching get rid of other content, this is OK because blog
     // post never opens with animations
     document.querySelectorAll("main section").forEach((e) => e.remove());
     window.clearTimeout(timeoutID);
     main.append(blogPostTpl.content.cloneNode(true));
 
     //set zero-md src attribute based on URL (href of link must match file name)
-    let filename = window.location.pathname.split("/")[2];
-    console.log(filename);
-    document.querySelector('zero-md').src = "/blog-posts/" + filename + ".md";
+    const slug = window.location.pathname.split("/")[2];
+    const metadata = blogPosts.get(slug);
+    if(metadata) {
+        document.title = `${metadata.title} | Blog | Sean Fuhrman`;
+    } else {
+        document.title = urlRoutes["/blog"].title;
+    }
+
+    const descriptionMeta = document.querySelector('meta[name="description"]');
+    if(descriptionMeta) {
+        const description = metadata && metadata.description ? metadata.description : urlRoutes["/blog"].description;
+        descriptionMeta.setAttribute("content", description);
+    }
+
+    document.querySelector('zero-md').src = `/blog-posts/${slug}.md`;
     document.body.style.backgroundColor = "var(--blog-background-color)";
 }
 


### PR DESCRIPTION
## Summary
- replace the hard-coded blog anchor list with containers that can be populated dynamically
- add a shared blogPosts metadata map and render the blog page from it, keeping published items sorted by date
- update blog post metadata and layout styling while formatting dates for the generated links

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_690a7ddc7864832092eacd2650a68714