### PR TITLE
Fix homepage background color bug and mobile sizing for projects/blog

### DIFF
--- a/global.css
+++ b/global.css
@@ -495,7 +495,7 @@ header {
 
 @media screen and (max-width: 750px) {
   #projects {
-    grid-template-rows: 200px 50px 420px;
+    grid-template-rows: 120px 50px 1fr;
     grid-template-columns: 1fr 1fr;
   }
   #projects header {
@@ -521,6 +521,10 @@ header {
     align-self: center;
     grid-row: 2 / 3;
     grid-column: 2 / 3;
+  }
+  projects-item {
+    width: 65%;
+    height: 400px;
   }
 }
 
@@ -773,6 +777,21 @@ projects-item {
   cursor: pointer;
   color: var(--blog-text-color);
   text-decoration: none;
+}
+
+@media screen and (max-width: 600px) {
+  #blog, #blog-post {
+    gap: 40px;
+  }
+  #blog-posts {
+    width: 100%;
+  }
+  #blog-container {
+    width: 92vw;
+  }
+  .markdown-body {
+    padding: 0 0.5rem;
+  }
 }
 
 #blog-posts a p {

--- a/main.js
+++ b/main.js
@@ -152,6 +152,8 @@ function initHomepage() {
     let homePageTpl = document.getElementById('homepage-tpl');
     main.append(homePageTpl.content.cloneNode(true));
 
+    document.body.style.backgroundColor = "var(--background-color)";
+
     // hookup our new toggle
     const btn = document.getElementById('nav-toggle');
     btn.addEventListener('click', () => {


### PR DESCRIPTION
- Reset body background color to --background-color when navigating back to homepage (was retaining subpage's dark blue color)
- Projects mobile: reduce header height, use 1fr for slider row, widen slider items to 65% with shorter height for better fit
- Blog/blog-post mobile: reduce gap from 100px to 40px, widen blog-posts to 100% and blog-container to 92vw so content isn't cramped

https://claude.ai/code/session_01YZaHUWrNXRifvKMZj48yME